### PR TITLE
Revert "Add make targets for ko, verify"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,21 +172,3 @@ deploy-localstack: $(KUBECTL)
 .PHONY: ci-e2e-kind
 ci-e2e-kind:
 	BUCKET_NAME=$(BUCKET_NAME) ./hack/ci-e2e-kind.sh
-
-# SKE-TARGETS
-
-.PHONY: verify
-verify: check fmt test
-
-
-.PHONY: verify-extended
-verify-extended: check check-generate fmt test test-integration
-
-export PUSH ?= false
-export REPO := reg3.infra.ske.eu01.stackit.cloud/stackitcloud/etcd-druid
-export TAG := $(VERSION)
-export GIT_TAG := $(shell git describe --tag --always --dirty)
-.PHONY: image
-images: $(KO)
-	KO_DOCKER_REPO=$(REPO) $(KO) build --image-label org.opencontainers.image.source="https://github.com/stackitcloud/etcd-druid" \
-	--sbom none -t $(TAG) -t $(GIT_TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) .

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -15,12 +15,10 @@
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
 SKAFFOLD                   := $(TOOLS_BIN_DIR)/skaffold
 KUSTOMIZE                  := $(TOOLS_BIN_DIR)/kustomize
-KO                         := $(TOOLS_BIN_DIR)/ko
 
 # default tool versions
 SKAFFOLD_VERSION ?= v1.38.0
 KUSTOMIZE_VERSION ?= v5.0.0
-KO_VERSION ?= v0.15.4
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
@@ -31,6 +29,3 @@ export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
 $(KUSTOMIZE):
 	@test -s $(TOOLS_BIN_DIR)/kustomize || GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
-
-$(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Reverts the commit that added make targets. All logic is moved to CI, so the fork can remain clean.

See https://github.com/stackitcloud/ske-ci-infra/pull/1118