### PR TITLE
Revert "* add stackit as provider (#4)"

### DIFF
--- a/pkg/utils/store.go
+++ b/pkg/utils/store.go
@@ -40,7 +40,6 @@ const (
 	openstack = "openstack"
 	dell      = "dell"
 	openshift = "openshift"
-	stackit   = "stackit"
 )
 
 const (
@@ -101,7 +100,7 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 		return GCS, nil
 	case dell, ECS:
 		return ECS, nil
-	case openshift, OCS, stackit:
+	case openshift, OCS:
 		return OCS, nil
 	case Local, druidv1alpha1.StorageProvider(strings.ToLower(Local)):
 		return Local, nil


### PR DESCRIPTION
This reverts commit 5778733ee6682fd451f1be28950bf390786d446d.

/kind cleanup

**What this PR does / why we need it**:
Cleanup after we changed the backup provider to the generic S3 provider.
